### PR TITLE
docs: fix stencijs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This a collection of charting [web components](https://en.wikipedia.org/wiki/Web
 
 ## Integrations
 
-[See here](https://stenciljs.com/docs/framework-integration)
+[See here](https://stenciljs.com/docs/overview)
 
 ## About
 


### PR DESCRIPTION
New link for framework integration on senciljs side.